### PR TITLE
对象没判断空的情况导致与gitops库同步出错

### DIFF
--- a/src/main/java/io/choerodon/devops/domain/service/impl/HandlerC7nReleaseRelationsServiceImpl.java
+++ b/src/main/java/io/choerodon/devops/domain/service/impl/HandlerC7nReleaseRelationsServiceImpl.java
@@ -91,7 +91,7 @@ public class HandlerC7nReleaseRelationsServiceImpl implements HandlerObjectFileR
                 devopsEnvCommandE = devopsEnvCommandRepository
                         .query(applicationInstanceE.getCommandId());
             }
-            if (!devopsEnvCommandE.getCommandType().equals(CommandType.DELETE.getType())) {
+            if (devopsEnvCommandE !=null && !devopsEnvCommandE.getCommandType().equals(CommandType.DELETE.getType())) {
                 DevopsEnvCommandE devopsEnvCommandE1 = new DevopsEnvCommandE();
                 devopsEnvCommandE1.setCommandType(CommandType.DELETE.getType());
                 devopsEnvCommandE1.setObject(ObjectType.INSTANCE.getType());


### PR DESCRIPTION
(cherry picked from commit 6bcdb3f)

问题可能是0.10升级到0.11的老数据和新逻辑不匹配导致的devopsEnvCommandE对象为空。