### PR TITLE
[FIX] Fix the problem that the same environment code of different clusters will not create the deploy keys

### DIFF
--- a/src/main/java/io/choerodon/devops/api/controller/v1/DevopsEnvironmentController.java
+++ b/src/main/java/io/choerodon/devops/api/controller/v1/DevopsEnvironmentController.java
@@ -395,9 +395,9 @@ public class DevopsEnvironmentController {
      * @param envId     环境Id
      */
     @Permission(type = ResourceType.PROJECT, roles = {InitRoleCode.PROJECT_OWNER, InitRoleCode.PROJECT_MEMBER})
-    @ApiOperation(value = "根据环境编码查询环境")
+    @ApiOperation(value = "重试gitOps")
     @GetMapping(value = "/{env_id}/retry")
-    public void queryByCode(
+    public void retryGitOps(
             @ApiParam(value = "项目ID", required = true)
             @PathVariable(value = "project_id") Long projectId,
             @ApiParam(value = "环境编码", required = true)

--- a/src/main/java/io/choerodon/devops/app/service/impl/DevopsEnvironmentServiceImpl.java
+++ b/src/main/java/io/choerodon/devops/app/service/impl/DevopsEnvironmentServiceImpl.java
@@ -545,14 +545,14 @@ public class DevopsEnvironmentServiceImpl implements DevopsEnvironmentService {
                     false);
         }
         devopsEnvironmentE.initGitlabEnvProjectId(TypeUtil.objToLong(gitlabProjectDO.getId()));
-        if (gitlabRepository.getDeployKeys(gitlabProjectDO.getId(), gitlabProjectPayload.getUserId()).isEmpty()) {
-            gitlabRepository.createDeployKey(
-                    gitlabProjectDO.getId(),
-                    gitlabProjectPayload.getPath(),
-                    devopsEnvironmentE.getEnvIdRsaPub(),
-                    true,
-                    gitlabProjectPayload.getUserId());
-        }
+
+        gitlabRepository.createDeployKey(
+                gitlabProjectDO.getId(),
+                gitlabProjectPayload.getPath() + "-" + devopsEnvironmentE.getClusterE().getId(),
+                devopsEnvironmentE.getEnvIdRsaPub(),
+                true,
+                gitlabProjectPayload.getUserId());
+
         ProjectHook projectHook = ProjectHook.allHook();
         projectHook.setEnableSslVerification(true);
         projectHook.setProjectId(gitlabProjectDO.getId());


### PR DESCRIPTION
1. Fix illegal naming in code.
2. Fix the problem that the same environment code of different clusters will not create the deploy keys.